### PR TITLE
Allow setting `statusCode`

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -66,7 +66,7 @@ class Router {
     while (!done) {
       result = await next();
       if (result) {
-        state.statusCode = 200;
+        state.statusCode = typeof state.statusCode === 'number' ? state.statusCode : 200;
         cb(state, result);
         return;
       }


### PR DESCRIPTION
One may want to redirect or give some other http status code even though content is returned.

`typeof === 'number'` is used instead of `isNaN()` because [it is more performant](https://jsperf.com/isnan-vs-typeof).